### PR TITLE
Fixed the issue of using js to open a new page

### DIFF
--- a/app/src/main/java/org/b3log/siyuan/MainActivity.java
+++ b/app/src/main/java/org/b3log/siyuan/MainActivity.java
@@ -366,7 +366,7 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
 
     @Override
     public void onBackPressed() {
-        webView.evaluateJavascript("javascript:window.goBack()", null);
+        webView.evaluateJavascript("javascript:window.goBack ? window.goBack() : window.history.back()", null);
     }
 
     @Override


### PR DESCRIPTION
当插件使用 `window.open` 打开一个同源页面时, 会在 WebView 内部打开该页面, 此时返回键会失效, 导致无法返回思源主界面

将 `window.goBack()` 替换为 `window.goBack ? window.goBack() : window.history.back()` 以改善这种情况