### PR TITLE
feat: 适配单应用设置语言 | application setting language

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+  xmlns:tools="http://schemas.android.com/tools"
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -27,7 +29,9 @@
         android:roundIcon="@drawable/icon"
         android:supportsRtl="true"
         android:theme="@style/Theme.SiYuan"
-        android:usesCleartextTraffic="true">
+        android:localeConfig="@xml/locales_config"
+        android:usesCleartextTraffic="true"
+        tools:targetApi="tiramisu">
 
         <activity
             android:name=".BootActivity"

--- a/app/src/main/java/org/b3log/siyuan/MainActivity.java
+++ b/app/src/main/java/org/b3log/siyuan/MainActivity.java
@@ -28,8 +28,8 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.Handler;
+import android.os.LocaleList;
 import android.os.Looper;
 import android.os.Message;
 import android.provider.MediaStore;
@@ -373,7 +373,7 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
         }
 
         final String appDir = getFilesDir().getAbsolutePath() + "/app";
-        final Locale locale = getResources().getConfiguration().locale;
+        final Locale locale = LocaleList.getDefault().get(0);
         final String workspaceBaseDir = getExternalFilesDir(null).getAbsolutePath();
         final String timezone = TimeZone.getDefault().getID();
         new Thread(() -> {
@@ -381,6 +381,10 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
             String lang = locale.getLanguage() + "_" + locale.getCountry();
             if (lang.toLowerCase().contains("cn")) {
                 lang = "zh_CN";
+            } else if (lang.toLowerCase().contains("es")) {
+                lang = "es_ES";
+            } else if (lang.toLowerCase().contains("fr")) {
+                lang = "fr_FR";
             } else {
                 lang = "en_US";
             }

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!-- 以下 ISO 639 参考：https://www.loc.gov/standards/iso639-2/php/code_list.php -->
+
+  <!--使用简体中文作为最终回退语言区域 -->
+  <locale android:name="zh-Hans"/>
+  <!-- 西班牙语 -->
+  <locale android:name="es"/>
+  <!-- 法语 -->
+  <locale android:name="fr"/>
+  <!-- 英语 -->
+  <locale android:name="en"/>
+  <!-- 繁体中文 -->
+  <locale android:name="zh-Hant"/>
+
+</locale-config>


### PR DESCRIPTION
### 我做了什么
在这个 PR，我将思源 Android 适配了【[适配单应用设置语言](https://developer.android.com/guide/topics/resources/localization?hl=zh-cn)】功能。

### 为什么要怎么做？
一直以来思源  Android 都是获取系统语言，也就是意味着如果在应用设置中调节的语言，在应用下一次启动中会默认还原。

### 怎么做会有什么不良反应？
没有。唯一的缺点就是修改完语言需要下一次启动思源 Android 才会生效。