### PR TITLE
Add `JSAndroid.setWebViewDebuggable` to enable/disable debugging mode of WebView

### DIFF
--- a/app/src/main/java/org/b3log/siyuan/JSAndroid.java
+++ b/app/src/main/java/org/b3log/siyuan/JSAndroid.java
@@ -60,6 +60,11 @@ public final class JSAndroid {
     }
 
     @JavascriptInterface
+    public void setWebViewDebuggingEnabled(final boolean debuggable) {
+        activity.setWebViewDebuggable(debuggable);
+    }
+
+    @JavascriptInterface
     public String readClipboard() {
         final ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
         final ClipData clipData = clipboard.getPrimaryClip();

--- a/app/src/main/java/org/b3log/siyuan/MainActivity.java
+++ b/app/src/main/java/org/b3log/siyuan/MainActivity.java
@@ -140,7 +140,7 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
 
         // 使用 Chromium 调试 WebView
         if (Utils.isDebugPackageAndMode(this)) {
-            WebView.setWebContentsDebuggingEnabled(true);
+            this.setWebViewDebuggable(true);
         }
 
         // 注册工具栏显示/隐藏跟随软键盘状态
@@ -707,6 +707,10 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
                 Toast.makeText(this, "Check WebView version failed: " + e.getMessage(), Toast.LENGTH_LONG).show();
             }
         }
+    }
+
+    public void setWebViewDebuggable(final boolean debuggable) {
+        WebView.setWebContentsDebuggingEnabled(debuggable);
     }
 
     private static boolean syncing;


### PR DESCRIPTION
添加 `JSAndroid.setWebViewDebuggable` 方法以手动开启/关闭 WebView 的调试模式
Add method `JSAndroid.setWebViewDebuggable` to manually turn on/off the debug mode of the WebView

方便社区开发者在安卓平台进行调试
It is convenient for community developers to debug on the Android platform

使用方法示例 | Usage Example:
```js
// enable the debug mode of the WebView
window.JSAndroid?.setWebViewDebuggable?.(true);

// disable the debug mode of the WebView
window.JSAndroid?.setWebViewDebuggable?.(false);
```