### PR TITLE
feat: add local file system folder picker for sync configuration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,8 @@
 
     <!-- 预约通知 -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!-- Local File System sync provider: allows the Go kernel to read/write arbitrary paths -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".App"

--- a/app/src/main/java/org/b3log/siyuan/JSAndroid.java
+++ b/app/src/main/java/org/b3log/siyuan/JSAndroid.java
@@ -364,6 +364,11 @@ public final class JSAndroid {
     }
 
     @JavascriptInterface
+    public void pickLocalSyncFolder() {
+        activity.pickLocalSyncFolder();
+    }
+
+    @JavascriptInterface
     public void changeStatusBarColor(final String color, final int appearanceMode) {
         if (Utils.isTablet(activity)) {
             return;

--- a/app/src/main/java/org/b3log/siyuan/MainActivity.java
+++ b/app/src/main/java/org/b3log/siyuan/MainActivity.java
@@ -32,6 +32,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.util.Log;
 import android.view.DragEvent;
@@ -108,6 +109,7 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
     private ValueCallback<Uri[]> uploadMessage;
     private static final int REQUEST_SELECT_FILE = 100;
     private static final int REQUEST_CAMERA = 101;
+    private static final int REQUEST_LOCAL_SYNC_FOLDER = 102;
 
     static int serverPort = 6906;
     static String webViewVer;
@@ -673,8 +675,54 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
         }
     }
 
+    public void pickLocalSyncFolder() {
+        final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        startActivityForResult(intent, REQUEST_LOCAL_SYNC_FOLDER);
+    }
+
+    private String resolveTreeUriToPath(final Uri treeUri) {
+        try {
+            final String docId = DocumentsContract.getTreeDocumentId(treeUri);
+            final String[] split = docId.split(":");
+            if (split.length < 1) {
+                return null;
+            }
+            final String type = split[0];
+            final String relativePath = split.length > 1 ? split[1] : "";
+            if ("primary".equalsIgnoreCase(type)) {
+                final String base = "/storage/emulated/0";
+                return relativePath.isEmpty() ? base : base + "/" + relativePath;
+            } else {
+                // SD card or USB OTG
+                final String base = "/storage/" + type;
+                return relativePath.isEmpty() ? base : base + "/" + relativePath;
+            }
+        } catch (final Exception e) {
+            Utils.logError("picker", "resolve tree URI failed", e);
+            return null;
+        }
+    }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (requestCode == REQUEST_LOCAL_SYNC_FOLDER) {
+            if (resultCode == RESULT_OK && intent != null) {
+                final Uri treeUri = intent.getData();
+                if (treeUri != null) {
+                    getContentResolver().takePersistableUriPermission(treeUri,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                    final String path = resolveTreeUriToPath(treeUri);
+                    if (path != null) {
+                        final String jsPath = path.replace("'", "\\'");
+                        runOnUiThread(() -> webView.evaluateJavascript(
+                                "window.siyuanAndroidFolderPickerResult('" + jsPath + "')", null));
+                    }
+                }
+            }
+            super.onActivityResult(requestCode, resultCode, intent);
+            return;
+        }
+
         if (null == uploadMessage) {
             super.onActivityResult(requestCode, resultCode, intent);
             return;

--- a/app/src/main/java/org/b3log/siyuan/MainActivity.java
+++ b/app/src/main/java/org/b3log/siyuan/MainActivity.java
@@ -34,6 +34,8 @@ import android.os.Looper;
 import android.os.Message;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.provider.Settings;
+import android.os.Environment;
 import android.util.Log;
 import android.view.DragEvent;
 import android.view.View;
@@ -676,6 +678,18 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
     }
 
     public void pickLocalSyncFolder() {
+        // MANAGE_EXTERNAL_STORAGE is required so the Go kernel can read/write
+        // the chosen path via standard POSIX file I/O (os.Open etc.).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+                && !Environment.isExternalStorageManager()) {
+            // Ask the user to grant "All files access" in system settings,
+            // then re-open the picker once they return.
+            final Intent settings = new Intent(
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                    Uri.parse("package:" + getPackageName()));
+            startActivityForResult(settings, REQUEST_LOCAL_SYNC_FOLDER);
+            return;
+        }
         final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
         startActivityForResult(intent, REQUEST_LOCAL_SYNC_FOLDER);
     }
@@ -706,6 +720,19 @@ public class MainActivity extends AppCompatActivity implements com.blankj.utilco
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (requestCode == REQUEST_LOCAL_SYNC_FOLDER) {
+            // Case 1: returning from ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION settings screen
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+                    && intent != null
+                    && Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION.equals(
+                            intent.getAction())) {
+                // Permission screen returned — now launch the actual picker if granted
+                if (Environment.isExternalStorageManager()) {
+                    final Intent picker = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+                    startActivityForResult(picker, REQUEST_LOCAL_SYNC_FOLDER);
+                }
+                return;
+            }
+            // Case 2: returning from the document tree picker
             if (resultCode == RESULT_OK && intent != null) {
                 final Uri treeUri = intent.getData();
                 if (treeUri != null) {


### PR DESCRIPTION
## Summary

This is the Android-native companion to [siyuan-note/siyuan#17199](https://github.com/siyuan-note/siyuan/pull/17199).

## Problem

The previous attempt (PR [#22](https://github.com/siyuan-note/siyuan-android/pull/22) by DD3Boh) had two issues:
1. **Race condition**: `getLocalFileSystemPath()` was a synchronous `@JavascriptInterface` that called `startActivityForResult()` (async — launches the system folder picker Activity) and immediately returned `getLocalSyncPath()`, which is always `null` because the Activity result has not arrived yet.
2. **Missing permission**: the Go kernel uses POSIX file I/O, which is silently denied by Android 11+ outside `Android/data/<package>/` unless `MANAGE_EXTERNAL_STORAGE` is granted. Without it, the kernel sync simply fails even if the user picks a valid folder.

## Solution

Async callback pattern using the existing `webView.evaluateJavascript()` mechanism already used throughout the app:

1. `JSAndroid.pickLocalSyncFolder()` — fire-and-forget bridge method; JS calls this to start the picker
2. `MainActivity.pickLocalSyncFolder()` — checks `MANAGE_EXTERNAL_STORAGE` first; if not granted, redirects to system Settings, then returns to open the picker; launches `ACTION_OPEN_DOCUMENT_TREE`
3. `MainActivity.onActivityResult()` — on `REQUEST_LOCAL_SYNC_FOLDER`, resolves the SAF tree URI to a real filesystem path, then pushes the result to JS via `webView.evaluateJavascript("window.siyuanAndroidFolderPickerResult('" + path + "')", null)`
4. `resolveTreeUriToPath()` — handles both:
   - Primary storage: `primary:SomeDir` → `/storage/emulated/0/SomeDir`
   - Secondary volumes (SD card / USB OTG): `<uuid>:SomeDir` → `/storage/<uuid>/SomeDir`
5. `takePersistableUriPermission()` — persists SAF read/write access across app restarts

## Key differences from PR [#22](https://github.com/siyuan-note/siyuan-android/pull/22)

| | PR \#22 | This PR |
|--|--|--|
| Permission | `READ/WRITE_EXTERNAL_STORAGE` (deprecated) | `MANAGE_EXTERNAL_STORAGE` (required for kernel POSIX I/O on API 30+) |
| API pattern | Synchronous `@JavascriptInterface` → race condition | Async callback via `evaluateJavascript()` |
| Path resolution | Only primary storage | Primary + SD card + USB OTG |
| Settings flow | None | Auto-prompts for "All files access" if not granted, then opens picker |

## Frontend companion

The corresponding frontend change (Browse button in the local provider UI, Android-only) is in KonTy/siyuan branch `feat/local-provider-android` ([siyuan-note/siyuan#17199](https://github.com/siyuan-note/siyuan/pull/17199)).